### PR TITLE
Makefile-libglnx.am: use README.md not README

### DIFF
--- a/Makefile-libglnx.am
+++ b/Makefile-libglnx.am
@@ -15,7 +15,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-EXTRA_DIST += $(libglnx_srcpath)/README $(libglnx_srcpath)/COPYING
+EXTRA_DIST += $(libglnx_srcpath)/README.md $(libglnx_srcpath)/COPYING
 
 libglnx_la_SOURCES = \
 	$(libglnx_srcpath)/glnx-backport-autocleanups.h \


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com
