### PR TITLE
glnx-fdio: always initialize buf

### DIFF
--- a/glnx-fdio.c
+++ b/glnx-fdio.c
@@ -211,7 +211,7 @@ glnx_file_get_contents_utf8_at (int                   dfd,
 {
   gboolean success = FALSE;
   glnx_fd_close int fd = -1;
-  char *buf;
+  char *buf = NULL;
   gsize len;
 
   dfd = glnx_dirfd_canonicalize (dfd);


### PR DESCRIPTION
It can be used without initialization if condition causing a "goto
error" fails before buf is initialized.

Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com
