### PR TITLE
libcontainer: Search $PATH for exec() if argv[0] is not absolute

### DIFF
--- a/glnx-libcontainer.c
+++ b/glnx-libcontainer.c
@@ -242,8 +242,16 @@ glnx_libcontainer_run_in_root (const char  *dest,
   if (chdir ("/") != 0)
     _perror_fatal ("chdir: ");
 
-  if (execv (binary, argv) != 0)
-    _perror_fatal ("execl: ");
+  if (binary[0] == '/')
+    {
+      if (execv (binary, argv) != 0)
+        _perror_fatal ("execv: ");
+    }
+  else
+    {
+      if (execvp (binary, argv) != 0)
+        _perror_fatal ("execv: ");
+    }
 
   g_assert_not_reached ();
 }


### PR DESCRIPTION
In Fedora rawhide, dracut switched from `/usr/sbin` to `/usr/bin`,
which broke rpm-ostree's hardcoding of the path.

There was no real reason to hardcode it (assume our `$PATH` is sane
and secure), so in order to help support that, this change in libglnx
will automatically search $PATH if the input is not absolute.

(This is a sane default for a process spawning library IMO)
