### PR TITLE
glnx_opendirat(): Mention the path in the GError when openat fails.

### DIFF
--- a/glnx-dirfd.c
+++ b/glnx-dirfd.c
@@ -68,7 +68,7 @@ glnx_opendirat (int             dfd,
   int ret = glnx_opendirat_with_errno (dfd, path, follow);
   if (ret == -1)
     {
-      glnx_set_prefix_error_from_errno (error, "%s", "openat");
+      glnx_set_prefix_error_from_errno (error, "%s: path: %s", "openat", path);
       return FALSE;
     }
   *out_fd = ret;


### PR DESCRIPTION
This little patch mentions the path that was passed to openat() when it fails. This makes debugging of, for instance, xdg-app-builder, easier.

Ideally, applications would not show the libglnx GError message directly to a user. They would instead create their own error messages that mention relevant context such as this file path. However, GError doesn't make it easy to throw a level-appropriate GError, which is probably why xdg-app-builder just passes the GError all the way up the call stack from libglnx, eventually printing its message out on stderr.
