### PR TITLE
text_percent_internal: fix space calculation

### DIFF
--- a/glnx-console.c
+++ b/glnx-console.c
@@ -221,20 +221,22 @@ text_percent_internal (const char *text,
 
   if (percentage == -1)
     {
+      const guint spacelen = ncolumns - input_textlen;
       fwrite (text, 1, input_textlen, stdout);
+      printpad (spaces, n_spaces, spacelen);
     }
   else
     {
       const guint textlen = MIN (input_textlen, ncolumns - bar_min);
       const guint barlen = ncolumns - (textlen + 1);;
-      
+
       if (textlen > 0)
         {
           fwrite (text, 1, textlen, stdout);
           fputc (' ', stdout);
         }
-  
-      { 
+
+      {
         const guint nbraces = 2;
         const guint textpercent_len = 5;
         const guint bar_internal_len = barlen - nbraces - textpercent_len;
@@ -246,10 +248,6 @@ text_percent_internal (const char *text,
         printpad (spaces, n_spaces, spacelen);
         fputc (']', stdout);
         fprintf (stdout, " %3d%%", percentage);
-      }
-
-      { const guint spacelen = ncolumns - textlen - barlen;
-        printpad (spaces, n_spaces, spacelen);
       }
     }
 


### PR DESCRIPTION
The final space padding wasn't accounting for the single space we add
after the text. This was causing a single space to overflow on the next
line.

This was causing an interesting issue. Whenever we started printing a
progress bar NOT at the last row possible of the tty, we would still
have a properly updated progress line since we restore the cursor pos
before each update.

However, if we started printing when at the last row of the tty, the
space overflow caused the terminal to move down by one line. Then,
because we always restored to the last row of the tty, we would keep
creating a new line at each update.
