### PR TITLE
fdio: deleting .tmp file on failure

### DIFF
--- a/glnx-fdio.c
+++ b/glnx-fdio.c
@@ -746,6 +746,8 @@ glnx_file_replace_contents_with_perms_at (int                   dfd,
 
   ret = TRUE;
  out:
+  if (!ret)
+    (void) unlink (tmppath);
   return ret;
 }
 


### PR DESCRIPTION
Added a quick check for failed replace_content to delete tmp file (if exists).
