### PR TITLE
fdio: Add open_tmpfile_linkable() and link_tmpfile_at()

### DIFF
--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -46,6 +46,29 @@ const char *glnx_basename (const char *path)
   return (basename) (path);
 }
 
+gboolean
+glnx_open_tmpfile_linkable_at (int dfd,
+                               const char *subpath,
+                               int flags,
+                               int *out_fd,
+                               char **out_path,
+                               GError **error);
+
+typedef enum {
+  GLNX_LINK_TMPFILE_REPLACE,
+  GLNX_LINK_TMPFILE_NOREPLACE,
+  GLNX_LINK_TMPFILE_NOREPLACE_IGNORE_EXIST
+} GLnxLinkTmpfileReplaceMode;
+
+gboolean
+glnx_link_tmpfile_at (int dfd,
+                      GLnxLinkTmpfileReplaceMode flags,
+                      int fd,
+                      const char *tmpfile_path,
+                      int target_dfd,
+                      const char *target,
+                      GError **error);
+
 GBytes *
 glnx_fd_readall_bytes (int               fd,
                        GCancellable     *cancellable,

--- a/glnx-missing-syscall.h
+++ b/glnx-missing-syscall.h
@@ -1,0 +1,54 @@
+/***
+  This file was originally part of systemd.
+
+  Copyright 2010 Lennart Poettering
+  Copyright 2016 Zbigniew Jędrzejewski-Szmek
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  systemd is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with systemd; If not, see <http://www.gnu.org/licenses/>.
+***/
+
+/* Missing glibc definitions to access certain kernel APIs */
+
+#if !HAVE_DECL_RENAMEAT2
+#  ifndef __NR_renameat2
+#    if defined __x86_64__
+#      define __NR_renameat2 316
+#    elif defined __arm__
+#      define __NR_renameat2 382
+#    elif defined _MIPS_SIM
+#      if _MIPS_SIM == _MIPS_SIM_ABI32
+#        define __NR_renameat2 4351
+#      endif
+#      if _MIPS_SIM == _MIPS_SIM_NABI32
+#        define __NR_renameat2 6315
+#      endif
+#      if _MIPS_SIM == _MIPS_SIM_ABI64
+#        define __NR_renameat2 5311
+#      endif
+#    elif defined __i386__
+#      define __NR_renameat2 353
+#    else
+#      warning "__NR_renameat2 unknown for your architecture"
+#    endif
+#  endif
+
+static inline int renameat2(int oldfd, const char *oldname, int newfd, const char *newname, unsigned flags) {
+#  ifdef __NR_renameat2
+        return syscall(__NR_renameat2, oldfd, oldname, newfd, newname, flags);
+#  else
+        errno = ENOSYS;
+        return -1;
+#  endif
+}
+#endif

--- a/glnx-missing.h
+++ b/glnx-missing.h
@@ -1,0 +1,52 @@
+#pragma once
+
+/***
+  This file was originally part of systemd.
+
+  Copyright 2010 Lennart Poettering
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  systemd is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with systemd; If not, see <http://www.gnu.org/licenses/>.
+***/
+
+/* Missing glibc definitions to access certain kernel APIs */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <uchar.h>
+#include <unistd.h>
+
+#if defined(__i386__) || defined(__x86_64__)
+
+/* The precise definition of __O_TMPFILE is arch specific, so let's
+ * just define this on x86 where we know the value. */
+
+#ifndef __O_TMPFILE
+#define __O_TMPFILE     020000000
+#endif
+
+/* a horrid kludge trying to make sure that this will fail on old kernels */
+#ifndef O_TMPFILE
+#define O_TMPFILE (__O_TMPFILE | O_DIRECTORY)
+#endif
+
+#endif
+
+#ifndef RENAME_NOREPLACE
+#define RENAME_NOREPLACE (1 << 0)
+#endif
+
+#include "glnx-missing-syscall.h"

--- a/libglnx.m4
+++ b/libglnx.m4
@@ -1,0 +1,15 @@
+AC_DEFUN([LIBGLNX_CONFIGURE],
+[
+AC_CHECK_DECLS([
+        renameat2,
+        ],
+        [], [], [[
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/mount.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <linux/loop.h>
+#include <linux/random.h>
+]])
+])


### PR DESCRIPTION
We had a bug previously where we failed to clean up a temporary file
in an error path.  This is a classic case where the new `O_TMPFILE`
API in Linux is nicer.

To implement this, as usual we start with some original bits from
systemd.  But in this case I ended up having to heavily modify it
because systemd doesn't support "link into place and overwrite".  They
don't actually use their tempfile code much at all in fact - as far as
I can tell, just in the coredump code.

Whereas in many apps, ostree included, a very common use case is
atomically updating an existing file, which is
`glnx_file_replace_contents_at()`, including subtleties like doing an
`fdatasync()` if the file already existed.

Implementing this then is slightly weird since we need to link() the
file into place, then rename() after.

It's still better though because if we e.g. hit `ENOSPC` halfway
through, we'll clean up the file automatically.

We still do keep the mode where we error out if the file exists.
Finally, the ostree core though does have a more unusual case where we
want to ignore EEXIST (allow concurrent object writers), so add
support for that now.

Note: One really confusing bug I had here was that `O_TMPFILE` ignores
the provided mode, and this caused ostree to write refs that weren't
world readable.

Rework things so we always call `fchmod()`, but as a consequence we're
no longer honoring umask in the default case.  I doubt anyone will
care, and if they do we should probably fix ostree to consistently use
a mode inherited from the repo or something.
