### PR TITLE
text_percent_internal: compare uints before printing

### DIFF
--- a/glnx-console.c
+++ b/glnx-console.c
@@ -221,9 +221,11 @@ text_percent_internal (const char *text,
 
   if (percentage == -1)
     {
-      const guint spacelen = ncolumns - input_textlen;
       fwrite (text, 1, input_textlen, stdout);
-      printpad (spaces, n_spaces, spacelen);
+
+      /* Overwrite remaining space, if any */
+      if (ncolumns > input_textlen)
+        printpad (spaces, n_spaces, ncolumns - input_textlen);
     }
   else
     {


### PR DESCRIPTION
A wild sordid tale of substractions and unsigned integers leads this
team of variables down a loonng path...

Reported-by: Gatis Paeglis gatis.paeglis@qt.io
