### PR TITLE
fdio: Only invoke fallocate() for sizes > 0

### DIFF
--- a/glnx-fdio.c
+++ b/glnx-fdio.c
@@ -926,12 +926,15 @@ glnx_file_replace_contents_with_perms_at (int                   dfd,
     len = strlen ((char*)buf);
 
   /* Note that posix_fallocate does *not* set errno but returns it. */
-  r = posix_fallocate (fd, 0, len);
-  if (r != 0)
+  if (len > 0)
     {
-      errno = r;
-      glnx_set_error_from_errno (error);
-      return FALSE;
+      r = posix_fallocate (fd, 0, len);
+      if (r != 0)
+        {
+          errno = r;
+          glnx_set_error_from_errno (error);
+          return FALSE;
+        }
     }
 
   if ((r = glnx_loop_write (fd, buf, len)) != 0)


### PR DESCRIPTION
In some cases we want to replace with zero size, and `posix_fallocate()`
is documented to return `EINVAL` in this case.

Making this change since I noticed it elsewhere.
