### PR TITLE
Add --disable-otmpfile

### DIFF
--- a/glnx-fdio.c
+++ b/glnx-fdio.c
@@ -122,7 +122,7 @@ glnx_open_tmpfile_linkable_at (int dfd,
    * tempoary path name used is returned in "ret_path". Use
    * link_tmpfile() below to rename the result after writing the file
    * in full. */
-#ifdef O_TMPFILE
+#if defined(O_TMPFILE) && !defined(DISABLE_OTMPFILE)
   fd = openat (dfd, subpath, O_TMPFILE|flags, 0600);
   if (fd == -1 && !(errno == ENOSYS || errno == EISDIR || errno == EOPNOTSUPP))
     {

--- a/libglnx.m4
+++ b/libglnx.m4
@@ -12,4 +12,13 @@ AC_CHECK_DECLS([
 #include <linux/loop.h>
 #include <linux/random.h>
 ]])
+
+AC_ARG_ENABLE(otmpfile,
+              [AS_HELP_STRING([--disable-otmpfile],
+                              [Disable use of O_TMPFILE [default=no]])],,
+              [enable_otmpfile=yes])
+AS_IF([test $enable_otmpfile = yes], [], [
+  AC_DEFINE([DISABLE_OTMPFILE], 1, [Define if we should avoid using O_TMPFILE])])
+
 ])
+


### PR DESCRIPTION
Some systems have bugs with it, so let's allow downstreams to easily
disable it.

https://bugzilla.gnome.org/show_bug.cgi?id=769453
https://github.com/ostreedev/ostree/issues/421
