### PR TITLE
libcontainer: Add a fd-relative API

### DIFF
--- a/glnx-libcontainer.h
+++ b/glnx-libcontainer.h
@@ -31,6 +31,10 @@
 #include <sys/capability.h>
 #include <sched.h>
 
+pid_t glnx_libcontainer_run_chroot_at_private (int          root_dfd,
+                                               const char  *binary,
+                                               char **argv);
+
 pid_t glnx_libcontainer_run_chroot_private (const char  *dest,
                                             const char  *binary,
                                             char **argv);


### PR DESCRIPTION
I'm porting rpm-ostree and need this.  Of course all this libcontainer
stuff will be nuked in favor of bubblewrap when everything comes
together.
