### PR TITLE
build: Add --enable-wrpseudo-compat

### DIFF
--- a/glnx-fdio.c
+++ b/glnx-fdio.c
@@ -60,6 +60,7 @@ rename_file_noreplace_at (int olddirfd, const char *oldpath,
                           gboolean ignore_eexist,
                           GError **error)
 {
+#ifndef ENABLE_WRPSEUDO_COMPAT
   if (renameat2 (olddirfd, oldpath, newdirfd, newpath, RENAME_NOREPLACE) < 0)
     {
       if (errno == EINVAL || errno == ENOSYS)
@@ -80,6 +81,7 @@ rename_file_noreplace_at (int olddirfd, const char *oldpath,
     }
   else
     return TRUE;
+#endif
 
   if (linkat (olddirfd, oldpath, newdirfd, newpath, 0) < 0)
     {
@@ -122,7 +124,7 @@ glnx_open_tmpfile_linkable_at (int dfd,
    * tempoary path name used is returned in "ret_path". Use
    * link_tmpfile() below to rename the result after writing the file
    * in full. */
-#if defined(O_TMPFILE) && !defined(DISABLE_OTMPFILE)
+#if defined(O_TMPFILE) && !defined(DISABLE_OTMPFILE) && !defined(ENABLE_WRPSEUDO_COMPAT)
   fd = openat (dfd, subpath, O_TMPFILE|flags, 0600);
   if (fd == -1 && !(errno == ENOSYS || errno == EISDIR || errno == EOPNOTSUPP))
     {

--- a/libglnx.m4
+++ b/libglnx.m4
@@ -20,5 +20,12 @@ AC_ARG_ENABLE(otmpfile,
 AS_IF([test $enable_otmpfile = yes], [], [
   AC_DEFINE([DISABLE_OTMPFILE], 1, [Define if we should avoid using O_TMPFILE])])
 
-])
+AC_ARG_ENABLE(wrpseudo-compat,
+              [AS_HELP_STRING([--enable-wrpseudo-compat],
+                              [Disable use syscall() and filesystem calls to for compatibility with wrpseudo [default=no]])],,
+              [enable_wrpseudo_compat=no])
+AS_IF([test $enable_wrpseudo_compat = no], [], [
+  AC_DEFINE([ENABLE_WRPSEUDO_COMPAT], 1, [Define if we should be compatible with wrpseudo])])
 
+dnl end LIBGLNX_CONFIGURE
+])


### PR DESCRIPTION
See https://mail.gnome.org/archives/ostree-list/2016-October/msg00003.html

Basically https://github.com/wrpseudo/pseudo doesn't implement newer
APIs like renameat2() and O_TMPFILE, so on the host side (as
potentially opposed to the target system) we want to be able to
disable them.
