### PR TITLE
dirfd: Set initialized flag for iters

### DIFF
--- a/glnx-dirfd.c
+++ b/glnx-dirfd.c
@@ -142,6 +142,7 @@ glnx_dirfd_iterator_init_take_fd (int                dfd,
 
   real_dfd_iter->fd = dfd;
   real_dfd_iter->d = d;
+  real_dfd_iter->initialized = TRUE;
 
   ret = TRUE;
  out:
@@ -169,6 +170,7 @@ glnx_dirfd_iterator_next_dent (GLnxDirFdIterator  *dfd_iter,
   GLnxRealDirfdIterator *real_dfd_iter = (GLnxRealDirfdIterator*) dfd_iter;
 
   g_return_val_if_fail (out_dent, FALSE);
+  g_return_val_if_fail (dfd_iter->initialized, FALSE);
 
   if (g_cancellable_set_error_if_cancelled (cancellable, error))
     goto out;
@@ -250,6 +252,8 @@ glnx_dirfd_iterator_clear (GLnxDirFdIterator *dfd_iter)
 {
   GLnxRealDirfdIterator *real_dfd_iter = (GLnxRealDirfdIterator*) dfd_iter;
   /* fd is owned by dfd_iter */
+  if (!real_dfd_iter->initialized)
+    return;
   (void) closedir (real_dfd_iter->d);
   real_dfd_iter->initialized = FALSE;
 }


### PR DESCRIPTION
And use it when deinitializing, to avoid calling `closedir(NULL)`.
In practice, this doesn't matter, because `closedir` _does_ handle `NULL`
in glibc.

However, I'm playing with the GCC `-fsanitize=undefined`, and it
aborts because `closedir` is tagged as requiring a non-`NULL` pointer.
