### PR TITLE
fdio: Make GLnxFileCopyFlags actually flags

### DIFF
--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -130,9 +130,9 @@ int
 glnx_loop_write (int fd, const void *buf, size_t nbytes);
 
 typedef enum {
-  GLNX_FILE_COPY_OVERWRITE,
-  GLNX_FILE_COPY_NOXATTRS,
-  GLNX_FILE_COPY_DATASYNC
+  GLNX_FILE_COPY_OVERWRITE = (1 << 0),
+  GLNX_FILE_COPY_NOXATTRS = (1 << 1),
+  GLNX_FILE_COPY_DATASYNC = (1 << 2)
 } GLnxFileCopyFlags;
 
 gboolean


### PR DESCRIPTION
I wanted to add a new one, and realized it was wrong.  Luckily,
I think we were safe until now, since the set of bits for `(0, 1, 2)`
is actually distinct.

Although, hm, callers specifying `GLNX_FILE_COPY_OVERWRITE` may
have not actually been getting that.
