### PR TITLE
tests/xattrs: Fix possible NULL allocation

### DIFF
--- a/tests/test-libglnx-xattrs.c
+++ b/tests/test-libglnx-xattrs.c
@@ -42,7 +42,7 @@ static gboolean
 set_random_xattr_value (int fd, const char *name, GError **error)
 {
   const guint8 randxattrbyte = g_random_int_range (0, 256);
-  const guint32 randxattrvalue_len = g_random_int () % 256; /* Picked to be not too small or large */
+  const guint32 randxattrvalue_len = (g_random_int () % 256) + 1; /* Picked to be not too small or large */
   g_autofree char *randxattrvalue = g_malloc (randxattrvalue_len);
 
   memset (randxattrvalue, randxattrbyte, randxattrvalue_len);


### PR DESCRIPTION
This showed up in the ostree runs with `-fsanitize=undefined` - if we happened
to get `0` then `g_malloc` would return `NULL`. However, what's interesting is
it seemed to happen *consistently*. I think what's going on is GCC proved that
the value *could* be zero, and hence it *could* return NULL, and hence it was
undefined behavior. Hooray for `-fsanitize=undefined`.