### PR TITLE
errors: Fix legacy set_prefix_error_from_errno()

### DIFF
--- a/glnx-errors.h
+++ b/glnx-errors.h
@@ -128,9 +128,7 @@ glnx_throw_errno_prefix (GError **error, const char *fmt, ...)
 
 #define glnx_set_prefix_error_from_errno(error, format, args...)  \
   do {                                                            \
-    glnx_set_error_from_errno (error);                            \
-    g_prefix_error (error, format, args);                         \
+    glnx_throw_errno_prefix (error, format, args);                \
   } while (0);
-
 
 G_END_DECLS

--- a/tests/test-libglnx-errors.c
+++ b/tests/test-libglnx-errors.c
@@ -83,6 +83,11 @@ test_error_errno (void)
       g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
       g_assert (g_str_has_prefix (error->message, glnx_strjoina ("Failed to open ", noent_path)));
       g_clear_error (&error);
+      /* And test the legacy wrapper */
+      glnx_set_prefix_error_from_errno (&error, "Failed to open %s", noent_path));
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (g_str_has_prefix (error->message, glnx_strjoina ("Failed to open ", noent_path)));
+      g_clear_error (&error);
     }
   else
     g_assert_cmpint (fd, ==, -1);


### PR DESCRIPTION
We were missing the previous automatic `: ` addition; noticed in
a failing ostree test.

Fix this by just calling the new API as the non-prefix case does too.