### PR TITLE
fdio: Expose glnx_regfile_copy_bytes(), rewrite: GNU style, POSIX errno

### DIFF
--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -131,6 +131,9 @@ glnx_readlinkat_malloc (int            dfd,
 int
 glnx_loop_write (int fd, const void *buf, size_t nbytes);
 
+int
+glnx_regfile_copy_bytes (int fdf, int fdt, off_t max_bytes, gboolean try_reflink);
+
 typedef enum {
   GLNX_FILE_COPY_OVERWRITE = (1 << 0),
   GLNX_FILE_COPY_NOXATTRS = (1 << 1),


### PR DESCRIPTION
In ostree in a few places we use `g_output_stream_splice()`.  I
thought this would use `splice()`, but actually it doesn't today.

They also, if a cancellable is provided, end up dropping into `poll()` for every
read and write. (In addition to copying data to/from userspace).

My opinion on this is - for *local files* that's dumb. In the big picture, you
really only need cancellation when copying gigabytes. Down the line, we could
perhaps add a `glnx_copy_bytes_cancellable()` that only did that check e.g.
every gigabyte of copied data. And when we do that we should use
`g_cancellable_set_error_if_cancelled()` rather than a `poll()` with the regular
file FD, since regular files are *always* readable and writable.

For my use case with rpm-ostree though, we don't have gigabyte sized files, and
seeing all of the `poll()` calls in strace is annoying. So let's have the
non-cancellable file copying API that's modern and uses both reflink and
`sendfile()` if available, in that order.

My plan at some point once this is tested more is to migrate this code
into GLib.