### PR TITLE
glnx-errors.h: add a glnx_throw_prefix() variant

### DIFF
--- a/glnx-errors.h
+++ b/glnx-errors.h
@@ -68,7 +68,7 @@ void glnx_real_set_prefix_error_va (GError     *error,
  * ```
  * */
 static inline gboolean G_GNUC_PRINTF (2,3)
-glnx_throw_prefix (GError **error, const char *fmt, ...)
+glnx_prefix_error (GError **error, const char *fmt, ...)
 {
   if (error == NULL)
     return FALSE;
@@ -80,9 +80,9 @@ glnx_throw_prefix (GError **error, const char *fmt, ...)
   return FALSE;
 }
 
-/* Like `glnx_throw_prefix ()`, but returns %NULL. */
-#define glnx_null_throw_prefix(error, args...) \
-  ({glnx_throw_prefix (error, args); NULL;})
+/* Like `glnx_prefix_error ()`, but returns %NULL. */
+#define glnx_prefix_error_null(error, args...) \
+  ({glnx_prefix_error (error, args); NULL;})
 
 /* Set @error using the value of `g_strerror (errno)`.
  *

--- a/glnx-errors.h
+++ b/glnx-errors.h
@@ -30,7 +30,7 @@ G_BEGIN_DECLS
  * This function returns %FALSE so it can be used conveniently in a single
  * statement:
  *
- * ``
+ * ```
  *   if (strcmp (foo, "somevalue") != 0)
  *     return glnx_throw (error, "key must be somevalue, not '%s'", foo);
  * ```
@@ -49,16 +49,47 @@ glnx_throw (GError **error, const char *fmt, ...)
   return FALSE;
 }
 
-/* Like glnx_throw(), but yields a NULL pointer. */
+/* Like `glnx_throw ()`, but returns %NULL. */
 #define glnx_null_throw(error, args...) \
   ({glnx_throw (error, args); NULL;})
+
+/* Implementation detail of glnx_throw_prefix() */
+void glnx_real_set_prefix_error_va (GError     *error,
+                                    const char *format,
+                                    va_list     args) G_GNUC_PRINTF (2,0);
+
+/* Prepend to @error's message by `$prefix: ` where `$prefix` is computed via
+ * printf @fmt. Returns %FALSE so it can be used conveniently in a single
+ * statement:
+ *
+ * ```
+ *   if (!function_that_fails (s, error))
+ *     return glnx_throw_prefix (error, "while handling '%s'", s);
+ * ```
+ * */
+static inline gboolean G_GNUC_PRINTF (2,3)
+glnx_throw_prefix (GError **error, const char *fmt, ...)
+{
+  if (error == NULL)
+    return FALSE;
+
+  va_list args;
+  va_start (args, fmt);
+  glnx_real_set_prefix_error_va (*error, fmt, args);
+  va_end (args);
+  return FALSE;
+}
+
+/* Like `glnx_throw_prefix ()`, but returns %NULL. */
+#define glnx_null_throw_prefix(error, args...) \
+  ({glnx_throw_prefix (error, args); NULL;})
 
 /* Set @error using the value of `g_strerror (errno)`.
  *
  * This function returns %FALSE so it can be used conveniently in a single
  * statement:
  *
- * ``
+ * ```
  *   if (unlinkat (fd, somepathname) < 0)
  *     return glnx_throw_errno (error);
  * ```

--- a/tests/test-libglnx-errors.c
+++ b/tests/test-libglnx-errors.c
@@ -60,7 +60,7 @@ test_error_errno (void)
     {
       g_assert (!glnx_throw_errno (&error));
       g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
-      g_assert (!glnx_throw_prefix (&error, "myprefix"));
+      g_assert (!glnx_prefix_error (&error, "myprefix"));
       g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
       g_assert (g_str_has_prefix (error->message, "myprefix: "));
       g_clear_error (&error);
@@ -74,7 +74,7 @@ test_error_errno (void)
       gpointer dummy = glnx_null_throw_errno (&error);
       g_assert (dummy == NULL);
       g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
-      dummy = glnx_null_throw_prefix (&error, "myprefix");
+      dummy = glnx_prefix_error_null (&error, "myprefix");
       g_assert (dummy == NULL);
       g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
       g_assert (g_str_has_prefix (error->message, "myprefix: "));

--- a/tests/test-libglnx-errors.c
+++ b/tests/test-libglnx-errors.c
@@ -60,6 +60,9 @@ test_error_errno (void)
     {
       g_assert (!glnx_throw_errno (&error));
       g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (!glnx_throw_prefix (&error, "myprefix"));
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (g_str_has_prefix (error->message, "myprefix: "));
       g_clear_error (&error);
     }
   else
@@ -71,6 +74,10 @@ test_error_errno (void)
       gpointer dummy = glnx_null_throw_errno (&error);
       g_assert (dummy == NULL);
       g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      dummy = glnx_null_throw_prefix (&error, "myprefix");
+      g_assert (dummy == NULL);
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (g_str_has_prefix (error->message, "myprefix: "));
       g_clear_error (&error);
     }
   else


### PR DESCRIPTION
For completeness. It just looks much cleaner than doing the `, FALSE`
trick. It also takes care of appending the ': ' for you like its errno
version.