### PR TITLE
fdio: Redo tmpfile API with GLnxTmpfile struct

### DIFF
--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -48,12 +48,20 @@ const char *glnx_basename (const char *path)
   return (basename) (path);
 }
 
+typedef struct {
+  int src_dfd;
+  int fd;
+  char *path;
+} GLnxTmpfile;
+#define GLNX_TMPFILE_INIT { .src_dfd = -1 };
+void glnx_tmpfile_clear (GLnxTmpfile *tmpf);
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxTmpfile, glnx_tmpfile_clear);
+
 gboolean
 glnx_open_tmpfile_linkable_at (int dfd,
                                const char *subpath,
                                int flags,
-                               int *out_fd,
-                               char **out_path,
+                               GLnxTmpfile *out_tmpf,
                                GError **error);
 
 typedef enum {
@@ -63,10 +71,8 @@ typedef enum {
 } GLnxLinkTmpfileReplaceMode;
 
 gboolean
-glnx_link_tmpfile_at (int dfd,
+glnx_link_tmpfile_at (GLnxTmpfile *tmpf,
                       GLnxLinkTmpfileReplaceMode flags,
-                      int fd,
-                      const char *tmpfile_path,
                       int target_dfd,
                       const char *target,
                       GError **error);


### PR DESCRIPTION
The core problem with the previous tmpfile code
is we don't have an autocleanup that calls `unlinkat`
in the non-`O_TMPFILE` case.  And even if we did, it'd
be awkward still since the `glnx_link_tmpfile_at()` call
*consumes* the tmpfile.

Fix this by introducing a struct with a cleanup macro. This simplifies a number
of the callers in libostree - a notable case is where we had two arrays, one of
fds, one of paths. It makes other places in libostree a bit more complex, but
that's because some of the commit code paths want to deal with temporary
*symlinks* too.

Most callers are better though - in libglnx itself, `glnx_file_copy_at()` now
correctly unlinks on failure for example.