### PR TITLE
fdio: Allow using AT_FDCWD with GlnxTmpfile

### DIFF
--- a/glnx-fdio.c
+++ b/glnx-fdio.c
@@ -150,8 +150,6 @@ glnx_renameat2_exchange (int olddirfd, const char *oldpath,
 void
 glnx_tmpfile_clear (GLnxTmpfile *tmpf)
 {
-  if (tmpf->src_dfd == -1)
-    return;
   if (tmpf->fd == -1)
     return;
   (void) close (tmpf->fd);
@@ -247,7 +245,7 @@ glnx_link_tmpfile_at (GLnxTmpfile *tmpf,
   const gboolean replace = (mode == GLNX_LINK_TMPFILE_REPLACE);
   const gboolean ignore_eexist = (mode == GLNX_LINK_TMPFILE_NOREPLACE_IGNORE_EXIST);
 
-  g_return_val_if_fail (tmpf->src_dfd >= 0, FALSE);
+  g_return_val_if_fail (tmpf->fd >= 0, FALSE);
 
   /* Unlike the original systemd code, this function also supports
    * replacing existing files.

--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -53,7 +53,7 @@ typedef struct {
   int fd;
   char *path;
 } GLnxTmpfile;
-#define GLNX_TMPFILE_INIT { .src_dfd = -1 };
+#define GLNX_TMPFILE_INIT { .fd = -1 };
 void glnx_tmpfile_clear (GLnxTmpfile *tmpf);
 G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxTmpfile, glnx_tmpfile_clear);
 


### PR DESCRIPTION
We use fd >= 0 to check for validity instead of src_dfd >= 0
because everything works just fine with src_dfd == AT_FDCWD,
except that is negative so the checks break.

This fixes flatpak which uses AT_FDCWD.