### PR TITLE
fdio: Allow using AT_FDCWD with GlnxTmpfile

### DIFF
--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -49,11 +49,11 @@ const char *glnx_basename (const char *path)
 }
 
 typedef struct {
+  gboolean initialized;
   int src_dfd;
   int fd;
   char *path;
 } GLnxTmpfile;
-#define GLNX_TMPFILE_INIT { .src_dfd = -1 };
 void glnx_tmpfile_clear (GLnxTmpfile *tmpf);
 G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxTmpfile, glnx_tmpfile_clear);
 


### PR DESCRIPTION
Add an `initialized` member which means we work by default
in structs allocated with `g_new0` etc. and don't need
a special initializer.  This also fixes a bug where
we need to support `src_dfd == -1` or `AT_FDCWD`.

This fixes flatpak which uses AT_FDCWD.

Modified-by: Colin Walters <walters@verbum.org>