### PR TITLE
fdio: Add wrappers for renameat(), unlinkat()

### DIFF
--- a/glnx-fdio.c
+++ b/glnx-fdio.c
@@ -319,15 +319,13 @@ glnx_link_tmpfile_at (GLnxTmpfile *tmpf,
                "Exhausted %u attempts to create temporary file", count);
               return FALSE;
             }
-          if (renameat (target_dfd, tmpname_buf, target_dfd, target) < 0)
+          if (!glnx_renameat (target_dfd, tmpname_buf, target_dfd, target, error))
             {
               /* This is currently the only case where we need to have
                * a cleanup unlinkat() still with O_TMPFILE.
                */
-              int errsv = errno;
               (void) unlinkat (target_dfd, tmpname_buf, 0);
-              errno = errsv;
-              return glnx_throw_errno_prefix (error, "renameat");
+              return FALSE;
             }
         }
       else

--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -244,8 +244,42 @@ glnx_fstatat (int           dfd,
               GError      **error)
 {
   if (TEMP_FAILURE_RETRY (fstatat (dfd, path, buf, flags)) != 0)
-    return glnx_throw_errno (error);
+    return glnx_throw_errno_prefix (error, "fstatat(%s)", path);
+  return TRUE;
+}
 
+/**
+ * glnx_renameat:
+ *
+ * Wrapper around renameat() which adds #GError support and ensures that it
+ * retries on %EINTR.
+ */
+static inline gboolean
+glnx_renameat (int           src_dfd,
+               const gchar  *src_path,
+               int           dest_dfd,
+               const gchar  *dest_path,
+               GError      **error)
+{
+  if (TEMP_FAILURE_RETRY (renameat (src_dfd, src_path, dest_dfd, dest_path)) != 0)
+    return glnx_throw_errno_prefix (error, "renameat(%s, %s)", src_path, dest_path);
+  return TRUE;
+}
+
+/**
+ * glnx_unlinkat:
+ *
+ * Wrapper around unlinkat() which adds #GError support and ensures that it
+ * retries on %EINTR.
+ */
+static inline gboolean
+glnx_unlinkat (int           dfd,
+               const gchar  *path,
+               int           flags,
+               GError      **error)
+{
+  if (TEMP_FAILURE_RETRY (unlinkat (dfd, path, flags)) != 0)
+    return glnx_throw_errno_prefix (error, "unlinkat(%s)", path);
   return TRUE;
 }
 

--- a/tests/test-libglnx-fdio.c
+++ b/tests/test-libglnx-fdio.c
@@ -80,11 +80,8 @@ test_renameat2_noreplace (void)
       glnx_set_error_from_errno (error);
       goto out;
     }
-  if (fstatat (destfd, "bar", &stbuf, AT_SYMLINK_NOFOLLOW) < 0)
-    {
-      glnx_set_error_from_errno (error);
-      goto out;
-    }
+  if (!glnx_fstatat (destfd, "bar", &stbuf, AT_SYMLINK_NOFOLLOW))
+    goto out;
 
   if (fstatat (srcfd, "foo", &stbuf, AT_SYMLINK_NOFOLLOW) == 0)
     g_assert_not_reached ();


### PR DESCRIPTION
Besides doing `TEMP_FAILURE_RETRY` and `GError` conversion,
these also prefix the error with arguments.