### PR TITLE
macros: Add a size check for hashtable iters

### DIFF
--- a/glnx-macros.h
+++ b/glnx-macros.h
@@ -120,6 +120,7 @@ G_BEGIN_DECLS
 
 #define _GLNX_HASH_TABLE_FOREACH_IMPL_KV(guard, ht, it, kt, k, vt, v)          \
     gboolean guard = TRUE;                                                     \
+    G_STATIC_ASSERT (sizeof (kt) == sizeof (void*));                           \
     for (GHashTableIter it;                                                    \
          guard && ({ g_hash_table_iter_init (&it, ht), TRUE; });               \
          guard = FALSE)                                                        \


### PR DESCRIPTION
If the user provides a less than pointer-sized type, we'll clobber other things
on the stack.

See https://github.com/ostreedev/ostree/pull/990/