### PR TITLE
errors: Add GLNX_AUTO_PREFIX_ERROR

### DIFF
--- a/glnx-errors.h
+++ b/glnx-errors.h
@@ -84,6 +84,18 @@ glnx_prefix_error (GError **error, const char *fmt, ...)
 #define glnx_prefix_error_null(error, args...) \
   ({glnx_prefix_error (error, args); NULL;})
 
+typedef struct {
+  const char *prefix;
+  GError **error;
+} GLnxAutoErrorPrefix;
+static inline void
+glnx_cleanup_auto_prefix_error (GLnxAutoErrorPrefix *prefix)
+{
+  g_prefix_error (prefix->error, "%s: ", prefix->prefix);
+}
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxAutoErrorPrefix, glnx_cleanup_auto_prefix_error)
+#define GLNX_AUTO_PREFIX_ERROR(text, error) g_auto(GLnxAutoErrorPrefix) _glnxautoprefixerror = { text, error }
+
 /* Set @error using the value of `g_strerror (errno)`.
  *
  * This function returns %FALSE so it can be used conveniently in a single

--- a/tests/test-libglnx-errors.c
+++ b/tests/test-libglnx-errors.c
@@ -125,6 +125,32 @@ test_error_errno (void)
     g_assert_cmpint (fd, ==, -1);
 }
 
+static void
+test_error_auto_nothrow (GError **error)
+{
+  GLNX_AUTO_PREFIX_ERROR("foo", error);
+  /* Side effect to avoid otherwise empty function */
+  g_assert_no_error (*error);
+}
+
+static void
+test_error_auto_throw (GError **error)
+{
+  GLNX_AUTO_PREFIX_ERROR("foo", error);
+  (void) glnx_throw (error, "oops");
+}
+
+static void
+test_error_auto (void)
+{
+  g_autoptr(GError) error = NULL;
+  test_error_auto_nothrow (&error);
+  g_assert_no_error (error);
+  test_error_auto_throw (&error);
+  g_assert_nonnull (error);
+  g_assert_cmpstr (error->message, ==, "foo: oops");
+}
+
 int main (int argc, char **argv)
 {
   int ret;
@@ -133,6 +159,7 @@ int main (int argc, char **argv)
 
   g_test_add_func ("/error-throw", test_error_throw);
   g_test_add_func ("/error-errno", test_error_errno);
+  g_test_add_func ("/error-auto", test_error_auto);
 
   ret = g_test_run();
 


### PR DESCRIPTION
In a lot of places in ostree, we end up prefixing errors in the *caller*.
Often we only have 1-2 callers, and doing the error prefixing isn't
too duplicative.  But there are definitely cases where it's cleaner
to do the prefixing in the callee.  We have functions that aren't
ported to new style for this reason (they still do the prefixing
in `out:`).

Introduce a cleanup-oriented version of error prefixing so we can port those
functions too.