### PR TITLE
dirfd: Add glnx_mkdirat_p()

### DIFF
--- a/glnx-dirfd.h
+++ b/glnx-dirfd.h
@@ -83,6 +83,32 @@ char *glnx_fdrel_abspath (int         dfd,
 
 void glnx_gen_temp_name (gchar *tmpl);
 
+/**
+ * glnx_mkdirat_p:
+ * @dfd: directory fd
+ * @path: Directory path
+ * @mode: Mode
+ * @error: Return location for a #GError, or %NULL
+ *
+ * Wrapper around mkdirat() which ignores adds #GError support, ensures that
+ * it retries on %EINTR, and also ignores `EEXIST`.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ */
+static inline gboolean
+glnx_mkdirat_p (int           dfd,
+                const char   *path,
+                mode_t        mode,
+                GError      **error)
+{
+  if (TEMP_FAILURE_RETRY (mkdirat (dfd, path, mode)) != 0)
+    {
+      if (G_UNLIKELY (errno != EEXIST))
+        return glnx_throw_errno_prefix (error, "mkdirat(%s)", path);
+    }
+  return TRUE;
+}
+
 gboolean glnx_mkdtempat (int dfd,
                          gchar *tmpl,
                          int mode,


### PR DESCRIPTION
Another one where we have a lot of inlines in ostree at least.
I debated a non-`_p` version, but most of those honestly could be `_p`
and it wouldn't matter.