### PR TITLE
 localalloc: Abort on EBADF from close() by default

### DIFF
--- a/glnx-local-alloc.h
+++ b/glnx-local-alloc.h
@@ -204,7 +204,8 @@ glnx_cleanup_close_fdp (int *fdp)
   if (fd >= 0)
     {
       errsv = errno;
-      (void) close (fd);
+      if (close (fd) < 0)
+        g_assert (errno != EBADF);
       errno = errsv;
     }
 }


### PR DESCRIPTION

systemd does this by default. I think we should treat this as a fatal error
since it can cause really painful-to-debug problems if we don't just get
EBADF but actually close something else's fd due to a race.