### PR TITLE
fdio: Merge systemd code to use copy_file_range(), drop reflink support

### DIFF
--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -170,7 +170,7 @@ int
 glnx_loop_write (int fd, const void *buf, size_t nbytes);
 
 int
-glnx_regfile_copy_bytes (int fdf, int fdt, off_t max_bytes, gboolean try_reflink);
+glnx_regfile_copy_bytes (int fdf, int fdt, off_t max_bytes);
 
 typedef enum {
   GLNX_FILE_COPY_OVERWRITE = (1 << 0),

--- a/glnx-missing-syscall.h
+++ b/glnx-missing-syscall.h
@@ -52,3 +52,44 @@ static inline int renameat2(int oldfd, const char *oldname, int newfd, const cha
 #  endif
 }
 #endif
+
+/* Copied from systemd git:
+   commit 6bda23dd6aaba50cf8e3e6024248cf736cc443ca
+   Author:     Yu Watanabe <watanabe.yu+github@gmail.com>
+   AuthorDate: Thu Jul 27 20:22:54 2017 +0900
+   Commit:     Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
+   CommitDate: Thu Jul 27 07:22:54 2017 -0400
+*/
+#if !HAVE_DECL_COPY_FILE_RANGE
+#  ifndef __NR_copy_file_range
+#    if defined(__x86_64__)
+#      define __NR_copy_file_range 326
+#    elif defined(__i386__)
+#      define __NR_copy_file_range 377
+#    elif defined __s390__
+#      define __NR_copy_file_range 375
+#    elif defined __arm__
+#      define __NR_copy_file_range 391
+#    elif defined __aarch64__
+#      define __NR_copy_file_range 285
+#    elif defined __powerpc__
+#      define __NR_copy_file_range 379
+#    elif defined __arc__
+#      define __NR_copy_file_range 285
+#    else
+#      warning "__NR_copy_file_range not defined for your architecture"
+#    endif
+#  endif
+
+static inline ssize_t copy_file_range(int fd_in, loff_t *off_in,
+                                      int fd_out, loff_t *off_out,
+                                      size_t len,
+                                      unsigned int flags) {
+#  ifdef __NR_copy_file_range
+        return syscall(__NR_copy_file_range, fd_in, off_in, fd_out, off_out, len, flags);
+#  else
+        errno = ENOSYS;
+        return -1;
+#  endif
+}
+#endif


### PR DESCRIPTION
This is the new standard API for this; all Linux filesystems will make use of
this if possible. For example, both NFS and XFS (with reflink enabled)
understand it.

Part of the reason I'm doing this is so that ostree's `/etc` merge will start
using XFS reflinks. But another major reason is to take the next step after and
copy this code into GLib as well, so that all of the general GLib users will
benefit; e.g. Nautilus will transparently do server copy offloads with NFS home
directories.

At the same time, I don't see a reason to still use reflinks. Systemd's code has
an option for this, and everything seems to use `COPY_REFLINK`; so not sure why
they exposed the option.  AFAICS, since upstream Linux
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a76b5b04375f974579c83433b06466758c0c552c
the btrfs ioctl is really the same thing as `copy_file_range`, so let's just use that.