### PR TITLE
glnx-console: Add missing NULL check before writing out text

### DIFF
--- a/glnx-console.c
+++ b/glnx-console.c
@@ -221,7 +221,8 @@ text_percent_internal (const char *text,
 
   if (percentage == -1)
     {
-      fwrite (text, 1, input_textlen, stdout);
+      if (text != NULL)
+        fwrite (text, 1, input_textlen, stdout);
 
       /* Overwrite remaining space, if any */
       if (ncolumns > input_textlen)


### PR DESCRIPTION
It’s possible that text is NULL on this path.

Coverity CID: 1376570

Signed-off-by: Philip Withnall <withnall@endlessm.com>