### PR TITLE
console: trim useless check

### DIFF
--- a/glnx-console.c
+++ b/glnx-console.c
@@ -275,7 +275,7 @@ void
 glnx_console_progress_text_percent (const char *text,
                                     guint percentage)
 {
-  g_return_if_fail (percentage >= 0 && percentage <= 100);
+  g_return_if_fail (percentage <= 100);
 
   text_percent_internal (text, percentage);
 }


### PR DESCRIPTION
The `percentage` var is a guint and so is always >= 0.

Coverity CID: 163703