### PR TITLE
fdio: Support taking ownership of tmpfile fd

### DIFF
--- a/glnx-fdio.c
+++ b/glnx-fdio.c
@@ -168,9 +168,11 @@ glnx_tmpfile_clear (GLnxTmpfile *tmpf)
     return;
   if (!tmpf->initialized)
     return;
-  if (tmpf->fd == -1)
-    return;
-  (void) close (tmpf->fd);
+  if (tmpf->fd != -1)
+    {
+      if (close (tmpf->fd) < 0)
+        g_assert (errno != EBADF);
+    }
   /* If ->path is set, we're likely aborting due to an error. Clean it up */
   if (tmpf->path)
     {

--- a/tests/test-libglnx-fdio.c
+++ b/tests/test-libglnx-fdio.c
@@ -171,6 +171,7 @@ test_stdio_file (void)
   if (!glnx_open_anonymous_tmpfile (O_RDWR|O_CLOEXEC, &tmpf, error))
     goto out;
   f = fdopen (tmpf.fd, "w");
+  tmpf.fd = -1; /* Ownership was transferred via fdopen() */
   if (!f)
     {
       (void)glnx_throw_errno_prefix (error, "fdopen");


### PR DESCRIPTION
While reading a strace I noticed a double close in the tests; this was because
we were missing an an assignment to `-1` in the tests. However, let's make
supporting this clearer by explicitly supporting the fd being `-1` while still
setting the `initialized` variable to `FALSE`. We also add the `EBADF` assertion
checking.