### PR TITLE
dirfd: Extend tmpdir API to support optional cleaning

### DIFF
--- a/glnx-dirfd.h
+++ b/glnx-dirfd.h
@@ -119,8 +119,14 @@ typedef struct {
   int fd;
   char *path;
 } GLnxTmpDir;
-void glnx_tmpdir_clear (GLnxTmpDir *tmpf);
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxTmpDir, glnx_tmpdir_clear)
+gboolean glnx_tmpdir_delete (GLnxTmpDir *tmpf, GCancellable *cancellable, GError **error);
+void glnx_tmpdir_unset (GLnxTmpDir *tmpf);
+static inline void
+glnx_tmpdir_cleanup (GLnxTmpDir *tmpf)
+{
+  (void)glnx_tmpdir_delete (tmpf, NULL, NULL);
+}
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxTmpDir, glnx_tmpdir_cleanup)
 
 gboolean glnx_mkdtempat (int dfd, const char *tmpl, int mode,
                          GLnxTmpDir *out_tmpdir, GError **error);


### PR DESCRIPTION
We have a use case in libostree's staging dirs where we try to reuse
them across multiple ostree txns, but we want the fd-relative bits
here.

Extend the tmpdir API to make deletion optional. While here, also extend the API
to support checking for errors when deleting for projects like libostree that
want to do so consistently.

Also while here, add a change to set the fd to `-1` after clearing to be extra
defensive.