### PR TITLE
tree-wide: Use our own syscall wrappers or error prefixing

### DIFF
--- a/glnx-dirfd.c
+++ b/glnx-dirfd.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include <glnx-dirfd.h>
+#include <glnx-fdio.h>
 #include <glnx-errors.h>
 #include <glnx-local-alloc.h>
 #include <glnx-shutil.h>
@@ -204,8 +205,8 @@ glnx_dirfd_iterator_next_dent_ensure_dtype (GLnxDirFdIterator  *dfd_iter,
       if (ret_dent->d_type == DT_UNKNOWN)
         {
           struct stat stbuf;
-          if (TEMP_FAILURE_RETRY (fstatat (dfd_iter->fd, ret_dent->d_name, &stbuf, AT_SYMLINK_NOFOLLOW)) != 0)
-            return glnx_throw_errno (error);
+          if (!glnx_fstatat (dfd_iter->fd, ret_dent->d_name, &stbuf, AT_SYMLINK_NOFOLLOW, error))
+            return FALSE;
           ret_dent->d_type = IFTODT (stbuf.st_mode);
         }
     }

--- a/glnx-lockfile.c
+++ b/glnx-lockfile.c
@@ -105,7 +105,7 @@ glnx_make_lock_file(int dfd, const char *p, int operation, GLnxLockFile *out_loc
                                 r = flock(fd, operation);
 
                         if (r < 0)
-                                return glnx_throw_errno(error);
+                                return glnx_throw_errno_prefix (error, "flock");
                 }
 
                 /* If we acquired the lock, let's check if the file
@@ -114,9 +114,8 @@ glnx_make_lock_file(int dfd, const char *p, int operation, GLnxLockFile *out_loc
                  * it. In such a case our acquired lock is worthless,
                  * hence try again. */
 
-                r = fstat(fd, &st);
-                if (r < 0)
-                        return glnx_throw_errno(error);
+                if (!glnx_fstat (fd, &st, error))
+                        return FALSE;
                 if (st.st_nlink > 0)
                         break;
 


### PR DESCRIPTION
Followup to similar commits in the ostree stack recently.