### PR TITLE
fdio: Open target dirname for glnx_file_copy_at()

### DIFF
--- a/tests/test-libglnx-fdio.c
+++ b/tests/test-libglnx-fdio.c
@@ -169,13 +169,23 @@ test_filecopy (void)
   _GLNX_TEST_DECLARE_ERROR(local_error, error);
   g_auto(GLnxTmpfile) tmpf = { 0, };
   const char foo[] = "foo";
+  struct stat stbuf;
+
+  if (!glnx_ensure_dir (AT_FDCWD, "subdir", 0755, error))
+    return;
 
   if (!glnx_file_replace_contents_at (AT_FDCWD, foo, (guint8*)foo, sizeof (foo),
                                       GLNX_FILE_REPLACE_NODATASYNC, NULL, error))
     return;
 
+  /* Copy it into both the same dir and a subdir */
   if (!glnx_file_copy_at (AT_FDCWD, foo, NULL, AT_FDCWD, "bar",
                           GLNX_FILE_COPY_NOXATTRS, NULL, error))
+    return;
+  if (!glnx_file_copy_at (AT_FDCWD, foo, NULL, AT_FDCWD, "subdir/bar",
+                          GLNX_FILE_COPY_NOXATTRS, NULL, error))
+    return;
+  if (!glnx_fstatat (AT_FDCWD, "subdir/bar", &stbuf, 0, error))
     return;
 
   if (glnx_file_copy_at (AT_FDCWD, foo, NULL, AT_FDCWD, "bar",
@@ -206,7 +216,6 @@ test_filecopy (void)
                           NULL, error))
     return;
 
-  struct stat stbuf;
   if (!glnx_fstatat_allow_noent (AT_FDCWD, "nosuchtarget", &stbuf, AT_SYMLINK_NOFOLLOW, error))
     return;
   g_assert_cmpint (errno, ==, ENOENT);


### PR DESCRIPTION
Particularly if `AT_FDCWD` is used, we need to open
in the target dir, otherwise we can get `EXDEV` when trying
to do the final link.

(Theoretically we can cross a mountpoint even with fd-relative
 though this is a lot less likely)