### PR TITLE
macros: use size_t for glnx_strjoina len

### DIFF
--- a/glnx-macros.h
+++ b/glnx-macros.h
@@ -38,7 +38,7 @@ G_BEGIN_DECLS
         ({                                                              \
                 const char *_appendees_[] = { a, __VA_ARGS__ };         \
                 char *_d_, *_p_;                                        \
-                int _len_ = 0;                                          \
+                size_t _len_ = 0;                                       \
                 unsigned _i_;                                           \
                 for (_i_ = 0; _i_ < G_N_ELEMENTS(_appendees_) && _appendees_[_i_]; _i_++) \
                         _len_ += strlen(_appendees_[_i_]);              \


### PR DESCRIPTION
This was in my workspace for a while.
`strlen` returns a `size_t` and `alloca` expects a `size_t`.