### PR TITLE
lockfile: Use an `initialized` member rather than explicit init

### DIFF
--- a/glnx-lockfile.c
+++ b/glnx-lockfile.c
@@ -126,21 +126,18 @@ glnx_make_lock_file(int dfd, const char *p, int operation, GLnxLockFile *out_loc
         /* Note that if this is not AT_FDCWD, the caller takes responsibility
          * for the fd's lifetime being >= that of the lock.
          */
+        out_lock->initialized = TRUE;
         out_lock->dfd = dfd;
-        out_lock->path = t;
-        out_lock->fd = fd;
+        out_lock->path = g_steal_pointer (&t);
+        out_lock->fd = glnx_steal_fd (&fd);
         out_lock->operation = operation;
-
-        fd = -1;
-        t = NULL;
-
         return TRUE;
 }
 
 void glnx_release_lock_file(GLnxLockFile *f) {
         int r;
 
-        if (!f)
+        if (!(f && f->initialized))
                 return;
 
         if (f->path) {
@@ -181,4 +178,5 @@ void glnx_release_lock_file(GLnxLockFile *f) {
                 (void) close (f->fd);
         f->fd = -1;
         f->operation = 0;
+        f->initialized = FALSE;
 }

--- a/glnx-lockfile.h
+++ b/glnx-lockfile.h
@@ -27,6 +27,7 @@
 #include "glnx-backport-autoptr.h"
 
 typedef struct GLnxLockFile {
+        gboolean initialized;
         int dfd;
         char *path;
         int fd;
@@ -37,5 +38,3 @@ gboolean glnx_make_lock_file(int dfd, const char *p, int operation, GLnxLockFile
 void glnx_release_lock_file(GLnxLockFile *f);
 
 G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxLockFile, glnx_release_lock_file)
-
-#define GLNX_LOCK_FILE_INIT { .fd = -1, .dfd = AT_FDCWD, .path = NULL }


### PR DESCRIPTION
This makes us more friendly to being embedded in a GObject or
the like that's fully zero-initialized, rather than relying on the special
`-1` value for the fd.

Calls to `glnx_release_lock_file()` become idempotent, so it's easy to call it
unconditionally in an object finalizer.