### PR TITLE
missing: Sync from latest systemd, add memfd_create()

### DIFF
--- a/glnx-missing.h
+++ b/glnx-missing.h
@@ -19,7 +19,17 @@
   along with systemd; If not, see <http://www.gnu.org/licenses/>.
 ***/
 
-/* Missing glibc definitions to access certain kernel APIs */
+/* Missing glibc definitions to access certain kernel APIs.
+   This file is last updated from systemd git:
+
+   commit 71e5200f94b22589922704aa4abdf95d4fe2e528
+   Author:     Daniel Mack <daniel@zonque.org>
+   AuthorDate: Tue Oct 18 17:57:10 2016 +0200
+   Commit:     Lennart Poettering <lennart@poettering.net>
+   CommitDate: Fri Sep 22 15:24:54 2017 +0200
+
+   Add abstraction model for BPF programs
+*/
 
 #include <errno.h>
 #include <fcntl.h>
@@ -29,13 +39,23 @@
 #include <uchar.h>
 #include <unistd.h>
 
-#if defined(__i386__) || defined(__x86_64__)
-
-/* The precise definition of __O_TMPFILE is arch specific, so let's
- * just define this on x86 where we know the value. */
+/* The precise definition of __O_TMPFILE is arch specific; use the
+ * values defined by the kernel (note: some are hexa, some are octal,
+ * duplicated as-is from the kernel definitions):
+ * - alpha, parisc, sparc: each has a specific value;
+ * - others: they use the "generic" value.
+ */
 
 #ifndef __O_TMPFILE
+#if defined(__alpha__)
+#define __O_TMPFILE     0100000000
+#elif defined(__parisc__) || defined(__hppa__)
+#define __O_TMPFILE     0400000000
+#elif defined(__sparc__) || defined(__sparc64__)
+#define __O_TMPFILE     0x2000000
+#else
 #define __O_TMPFILE     020000000
+#endif
 #endif
 
 /* a horrid kludge trying to make sure that this will fail on old kernels */
@@ -43,13 +63,33 @@
 #define O_TMPFILE (__O_TMPFILE | O_DIRECTORY)
 #endif
 
-#endif
-
 #ifndef RENAME_NOREPLACE
 #define RENAME_NOREPLACE (1 << 0)
 #endif
 #ifndef RENAME_EXCHANGE
 #define RENAME_EXCHANGE (1 << 1)
+#endif
+
+#ifndef F_LINUX_SPECIFIC_BASE
+#define F_LINUX_SPECIFIC_BASE 1024
+#endif
+
+#ifndef F_ADD_SEALS
+#define F_ADD_SEALS (F_LINUX_SPECIFIC_BASE + 9)
+#define F_GET_SEALS (F_LINUX_SPECIFIC_BASE + 10)
+
+#define F_SEAL_SEAL     0x0001  /* prevent further seals from being set */
+#define F_SEAL_SHRINK   0x0002  /* prevent file from shrinking */
+#define F_SEAL_GROW     0x0004  /* prevent file from growing */
+#define F_SEAL_WRITE    0x0008  /* prevent writes */
+#endif
+
+#ifndef MFD_ALLOW_SEALING
+#define MFD_ALLOW_SEALING 0x0002U
+#endif
+
+#ifndef MFD_CLOEXEC
+#define MFD_CLOEXEC 0x0001U
 #endif
 
 #include "glnx-missing-syscall.h"

--- a/libglnx.h
+++ b/libglnx.h
@@ -25,6 +25,7 @@
 G_BEGIN_DECLS
 
 #include <glnx-macros.h>
+#include <glnx-missing.h>
 #include <glnx-local-alloc.h>
 #include <glnx-backport-autocleanups.h>
 #include <glnx-backports.h>

--- a/libglnx.m4
+++ b/libglnx.m4
@@ -1,8 +1,6 @@
 AC_DEFUN([LIBGLNX_CONFIGURE],
 [
-AC_CHECK_DECLS([
-        renameat2,
-        ],
+AC_CHECK_DECLS([renameat2, memfd_create],
         [], [], [[
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
Planning to use memfd_create() in flatpak and rpm-ostree, which both use
bubblewrap, and want to pass read-only data via file descriptor to the
container. Passing via `O_TMPFILE` requires `O_RDWR` (read and write),
and passing via a pipe would require buffering.

The systemd `missing.h` has grown enormously; I only cherry-picked the bits for
memfd.