### PR TITLE
fdio: Generate tmpname for RENAME_EXCHANGE fallback

### DIFF
--- a/glnx-fdio.c
+++ b/glnx-fdio.c
@@ -143,6 +143,13 @@ glnx_renameat2_exchange (int olddirfd, const char *oldpath,
   /* Fallback */
   { const char *old_tmp_name = glnx_strjoina (oldpath, ".XXXXXX");
 
+    /* This obviously isn't race-free, but doing better gets tricky, since if
+     * we're here the kernel isn't likely to support RENAME_NOREPLACE either.
+     * Anyways, upgrade the kernel. Failing that, avoid use of this function in
+     * shared subdirectories like /tmp.
+     */
+    glnx_gen_temp_name (old_tmp_name);
+
     /* Move old out of the way */
     if (renameat (olddirfd, oldpath, olddirfd, old_tmp_name) < 0)
       return -1;


### PR DESCRIPTION
I was using this in rpm-ostree and glanced at the code. This was clearly the
intent, but isn't a full fix. See code comments for more details.