### PR TITLE
Add glnx_fd_close() and glnx_autofd

### DIFF
--- a/glnx-dirfd.c
+++ b/glnx-dirfd.c
@@ -382,8 +382,7 @@ _glnx_tmpdir_free (GLnxTmpDir *tmpd,
   if (!(tmpd && tmpd->initialized))
     return TRUE;
   g_assert_cmpint (tmpd->fd, !=, -1);
-  (void) close (tmpd->fd);
-  tmpd->fd = -1;
+  glnx_close_fd (&tmpd->fd);
   g_assert (tmpd->path);
   g_assert_cmpint (tmpd->src_dfd, !=, -1);
   g_autofree char *path = tmpd->path; /* Take ownership */

--- a/glnx-lockfile.c
+++ b/glnx-lockfile.c
@@ -119,8 +119,7 @@ glnx_make_lock_file(int dfd, const char *p, int operation, GLnxLockFile *out_loc
                 if (st.st_nlink > 0)
                         break;
 
-                (void) close(fd);
-                fd = -1;
+                glnx_close_fd (&fd);
         }
 
         /* Note that if this is not AT_FDCWD, the caller takes responsibility
@@ -174,9 +173,7 @@ void glnx_release_lock_file(GLnxLockFile *f) {
                 f->path = NULL;
         }
 
-        if (f->fd != -1)
-                (void) close (f->fd);
-        f->fd = -1;
+        glnx_close_fd (&f->fd);
         f->operation = 0;
         f->initialized = FALSE;
 }


### PR DESCRIPTION
I'd like to have the checks for `EBADF` as well as the
"assign to -1" in more places.  The cleanup function we
had for `glnx_fd_close` is actually what we want.

Let's rename the cleanup macro to `glnx_autofd` to better match
other autocleanups like `g_autofree`.

Then we can use `glnx_fd_close()` as a replacement for plain Unix `close()`. I
left the `glnx_close_fd` macro, but it's obviously confusing now with the
former. We'll eventually remove it.