### PR TITLE
fdio: allow NULL for fstatat_allow_noent stbuf

### DIFF
--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -299,7 +299,7 @@ glnx_fstatat (int           dfd,
  * glnx_fstatat_allow_noent:
  * @dfd: Directory FD to stat beneath
  * @path: Path to stat beneath @dfd
- * @buf: (out caller-allocates): Return location for stat details
+ * @buf: (out caller-allocates) (allow-none): Return location for stat details
  * @flags: Flags to pass to fstatat()
  * @error: Return location for a #GError, or %NULL
  *
@@ -318,7 +318,8 @@ glnx_fstatat_allow_noent (int               dfd,
                           int               flags,
                           GError          **error)
 {
-  if (TEMP_FAILURE_RETRY (fstatat (dfd, path, out_buf, flags)) != 0)
+  struct stat stbuf;
+  if (TEMP_FAILURE_RETRY (fstatat (dfd, path, out_buf ?: &stbuf, flags)) != 0)
     {
       if (errno != ENOENT)
         {

--- a/tests/test-libglnx-fdio.c
+++ b/tests/test-libglnx-fdio.c
@@ -161,6 +161,16 @@ test_fstatat (void)
     return;
   g_assert_cmpint (errno, ==, ENOENT);
   g_assert_no_error (local_error);
+
+  /* test NULL parameter for stat */
+  if (!glnx_fstatat_allow_noent (AT_FDCWD, ".", NULL, 0, error))
+    return;
+  g_assert_cmpint (errno, ==, 0);
+  g_assert_no_error (local_error);
+  if (!glnx_fstatat_allow_noent (AT_FDCWD, "nosuchfile", NULL, 0, error))
+    return;
+  g_assert_cmpint (errno, ==, ENOENT);
+  g_assert_no_error (local_error);
 }
 
 static void


### PR DESCRIPTION
Often, the caller doesn't actually care about the details of the stat
struct itself, but just whether the entry exists or not. It does work
to just pass `NULL` directly to glibc in a quick test, but given that
the argument is tagged as `__nonnull` and that the documentation does
not explicitly specify this is supported, let's do this safely.