### PR TITLE
fdio: Avoid ?: syntax for fstatat_allow_noent()

### DIFF
--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -318,16 +318,12 @@ glnx_fstatat_allow_noent (int               dfd,
                           int               flags,
                           GError          **error)
 {
-  struct stat stbuf;
-  if (TEMP_FAILURE_RETRY (fstatat (dfd, path, out_buf ?: &stbuf, flags)) != 0)
+  G_GNUC_UNUSED struct stat unused_stbuf;
+  if (TEMP_FAILURE_RETRY (fstatat (dfd, path, out_buf ? out_buf : &unused_stbuf, flags)) != 0)
     {
       if (errno != ENOENT)
-        {
-          int errsv = errno;
-          (void) glnx_throw_errno_prefix (error, "fstatat(%s)", path);
-          errno = errsv;
-          return FALSE;
-        }
+        return glnx_throw_errno_prefix (error, "fstatat(%s)", path);
+      /* Note we preserve errno as ENOENT */
     }
   else
     errno = 0;


### PR DESCRIPTION
`g-ir-scanner` is unaware of this GNUC extension and complains.
Saw that while building ostree.

While we're here, fix up a few other things:

 - Tell the compiler the stat buffer is unused (I didn't see
   a warning, just doing this on general principle)
 - Return from `glnx_throw_errno_prefix()` directly; we do
   preserve errno there, let's feel free to rely on it.