### PR TITLE
Add missing configure check for copy_file_range

### DIFF
--- a/libglnx.m4
+++ b/libglnx.m4
@@ -1,6 +1,9 @@
 AC_DEFUN([LIBGLNX_CONFIGURE],
 [
-AC_CHECK_DECLS([renameat2, memfd_create],
+AC_CHECK_DECLS([
+        renameat2,
+        memfd_create,
+        copy_file_range],
         [], [], [[
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
Without this, including glnx-missing-syscall.h raises this warning:

    ../ext/libglnx/glnx-missing-syscall.h:121:6: warning: "HAVE_DECL_COPY_FILE_RANGE" is not defined [-Wundef]
     #if !HAVE_DECL_COPY_FILE_RANGE
          ^~~~~~~~~~~~~~~~~~~~~~~~~