### PR TITLE
missing-syscall: #include config.h

### DIFF
--- a/glnx-missing-syscall.h
+++ b/glnx-missing-syscall.h
@@ -30,6 +30,7 @@
    Add abstraction model for BPF programs
 */
 
+#include "config.h"
 
 #if !HAVE_DECL_RENAMEAT2
 #  ifndef __NR_renameat2


### PR DESCRIPTION
Followup to previous commit; this helps me build libostree
with `-Werror=undef`.