### PR TITLE
fdio: implement glnx_basename from scratch

### DIFF
--- a/glnx-fdio.h
+++ b/glnx-fdio.h
@@ -29,12 +29,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <sys/xattr.h>
-/* From systemd/src/shared/util.h */
-/* When we include libgen.h because we need dirname() we immediately
- * undefine basename() since libgen.h defines it as a macro to the XDG
- * version which is really broken. */
-#include <libgen.h>
-#undef basename
 
 #include <glnx-macros.h>
 #include <glnx-errors.h>
@@ -47,7 +41,14 @@ G_BEGIN_DECLS
 static inline
 const char *glnx_basename (const char *path)
 {
-  return (basename) (path);
+  gchar *base;
+
+  base = strrchr (path, G_DIR_SEPARATOR);
+
+  if (base)
+    return base + 1;
+
+  return path;
 }
 
 /* Utilities for standard FILE* */


### PR DESCRIPTION
At the top of glnx-fdio.h there's this comment:

/* When we include libgen.h because we need
 * dirname() we immediately undefine
 * basename() since libgen.h defines it as
 * a macro to the XDG version which is really
 * broken. */

and then it does #undef basename to try to
gain access to non-default basename implementation.

The problem is that this trick doesn't work on
some systems:

./libglnx/glnx-fdio.h: In function 'glnx_basename':
./libglnx/glnx-fdio.h:46:11: error: 'basename'
undeclared (first use in this function)
   return (basename) (path);

Anyway, basename() is like 3 lines of code to
implement, so this commit just does that instead
of relying on glibc for it.