### PR TITLE
Include sys/mman.h when checking for memfd_create

### DIFF
--- a/libglnx.m4
+++ b/libglnx.m4
@@ -12,6 +12,7 @@ AC_CHECK_DECLS([
 #include <sched.h>
 #include <linux/loop.h>
 #include <linux/random.h>
+#include <sys/mman.h>
 ]])
 
 AC_ARG_ENABLE(otmpfile,


### PR DESCRIPTION
glibc 2.27 added support for memfd_create. Unfortunately flatpak-builder,
or rather the included libglnx library, also has such a function to
wrap the corresponding syscall. It correctly tries to detect it in
the configure script to disabled the wrapper in case glibc provides
it. However it doesn't work due to a missing include.

Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=890722

---

Patch provided by Aurelien Jarno, originally attached to the Debian bug.

@alexlarsson: please include this in flatpak-builder when it's been merged here.