### PR TITLE
console: Drop newline on glnx_console_lock

### DIFF
--- a/glnx-console.c
+++ b/glnx-console.c
@@ -168,7 +168,7 @@ glnx_console_lock (GLnxConsoleRef *console)
           g_once_init_leave (&sigwinch_initialized, 1);
         }
       
-      { static const char initbuf[] = { '\n', 0x1B, 0x37 };
+      { static const char initbuf[] = { 0x1B, 0x37 };
         (void) fwrite (initbuf, 1, sizeof (initbuf), stdout);
       }
     }


### PR DESCRIPTION
This was inherited from some other code; perhaps the idea
was to ensure the console is in a consistent state before starting
a progress bar, but it causes extra newlines which is distracting.